### PR TITLE
(partially) Fix pre-trained LoRA loading

### DIFF
--- a/mammal/examples/tcr_epitope_binding/main_infer.py
+++ b/mammal/examples/tcr_epitope_binding/main_infer.py
@@ -40,8 +40,8 @@ def main(tcr_beta_seq: str, epitope_seq: str, device: str):
 
 def load_model(
     device: str,
-    model_path: str = "ibm/biomed.omics.bl.sm.ma-ted-458m.tcr_epitope_bind",  # change to "ibm/biomed.omics.bl.sm.ma-ted-458m" to try on the base model
-    tokenizer_path: str = "ibm/biomed.omics.bl.sm.ma-ted-458m.tcr_epitope_bind",
+    model_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m",  # change to "ibm/biomed.omics.bl.sm.ma-ted-458m" to try on the base model
+    tokenizer_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
 ) -> tuple["Mammal", "ModularTokenizerOp"]:
 
     # Load Model and set to evaluation mode

--- a/mammal/examples/tcr_epitope_binding/main_infer.py
+++ b/mammal/examples/tcr_epitope_binding/main_infer.py
@@ -40,8 +40,8 @@ def main(tcr_beta_seq: str, epitope_seq: str, device: str):
 
 def load_model(
     device: str,
-    model_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m",  # change to "ibm/biomed.omics.bl.sm.ma-ted-458m" to try on the base model
-    tokenizer_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m",
+    model_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m.tcr_epitope_bind",  # change to "ibm/biomed.omics.bl.sm.ma-ted-458m" to try on the base model
+    tokenizer_path: str = "ibm-research/biomed.omics.bl.sm.ma-ted-458m.tcr_epitope_bind",
 ) -> tuple["Mammal", "ModularTokenizerOp"]:
 
     # Load Model and set to evaluation mode

--- a/mammal/lora.py
+++ b/mammal/lora.py
@@ -46,10 +46,6 @@ def get_lora_model(
             pattern is not in the common layers pattern.
     """
 
-    # freeze all parameters in model:
-    for param in model.parameters():
-        param.requires_grad = False
-
     # build lora config
     config = LoraConfig(
         peft_type=peft_type,

--- a/mammal/model.py
+++ b/mammal/model.py
@@ -495,11 +495,14 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                         "LoRA weights found in state_dict, but 'config.use_lora' is False."
                     )
 
-                if config.use_lora:
+                if config.use_lora and pretrained_has_lora_weights:
                     model.t5_model = get_lora_model(model.t5_model)
 
                 # Inject weights to model instance
                 model.load_state_dict(state_dict, strict=strict)
+
+                if config.use_lora and not pretrained_has_lora_weights:
+                    model.t5_model = get_lora_model(model.t5_model)
 
         elif os.path.isdir(pretrained_model_name_or_path):
             print(
@@ -529,7 +532,7 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                     "LoRA weights found in state_dict, but 'config.use_lora' is False."
                 )
 
-            if config.use_lora:
+            if config.use_lora and pretrained_has_lora_weights:
                 model.t5_model = get_lora_model(model.t5_model)
 
             if hasattr(config, "random_weights") and config.random_weights:
@@ -539,6 +542,9 @@ class Mammal(ModelHubMixin, torch.nn.Module):
             else:
                 # Inject weights to model instance
                 load_model(model, model_safetensors_path, strict=strict)
+
+            if config.use_lora and not pretrained_has_lora_weights:
+                model.t5_model = get_lora_model(model.t5_model)
 
         else:
             raise ValueError()

--- a/mammal/model.py
+++ b/mammal/model.py
@@ -497,12 +497,14 @@ class Mammal(ModelHubMixin, torch.nn.Module):
 
                 if config.use_lora and pretrained_has_lora_weights:
                     model.t5_model = get_lora_model(model.t5_model)
+                    model.load_state_dict(state_dict, strict=strict)
 
-                # Inject weights to model instance
-                model.load_state_dict(state_dict, strict=strict)
-
-                if config.use_lora and not pretrained_has_lora_weights:
+                elif config.use_lora and not pretrained_has_lora_weights:
+                    model.load_state_dict(state_dict, strict=strict)
                     model.t5_model = get_lora_model(model.t5_model)
+
+                else:
+                    model.load_state_dict(state_dict, strict=strict)
 
         elif os.path.isdir(pretrained_model_name_or_path):
             print(

--- a/mammal/model.py
+++ b/mammal/model.py
@@ -406,7 +406,7 @@ class Mammal(ModelHubMixin, torch.nn.Module):
         """
         if not os.path.exists(pretrained_model_name_or_path):
             print(
-                f"Path doesn't exist. Will try to download fron hf hub. {pretrained_model_name_or_path=}"
+                f"Path doesn't exist. Will try to download from hf hub. {pretrained_model_name_or_path=}"
             )
             # Download ckpt dir from HF
             try:
@@ -547,7 +547,7 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                 model.t5_model = get_lora_model(model.t5_model)
 
         else:
-            raise ValueError()
+            raise ValueError(f"Got an invalid input, {pretrained_model_name_or_path=}")
         return model
 
     @property

--- a/mammal/model.py
+++ b/mammal/model.py
@@ -500,10 +500,12 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                     )
 
                 if config.use_lora and pretrained_has_lora_weights:
+                    print("Loading model with existing LoRA weights in it")
                     model.t5_model = get_lora_model(model.t5_model)
                     model.load_state_dict(state_dict, strict=strict)
 
                 elif config.use_lora and not pretrained_has_lora_weights:
+                    print("Loading model and create new LoRA weights on it")
                     model.load_state_dict(state_dict, strict=strict)
                     model.t5_model = get_lora_model(model.t5_model)
 
@@ -539,6 +541,7 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                 )
 
             if config.use_lora and pretrained_has_lora_weights:
+                print("Loading model with existing LoRA weights in it")
                 model.t5_model = get_lora_model(model.t5_model)
 
             if hasattr(config, "random_weights") and config.random_weights:
@@ -550,6 +553,7 @@ class Mammal(ModelHubMixin, torch.nn.Module):
                 load_model(model, model_safetensors_path, strict=strict)
 
             if config.use_lora and not pretrained_has_lora_weights:
+                print("Loading model and create new LoRA weights on it")
                 model.t5_model = get_lora_model(model.t5_model)
 
         else:


### PR DESCRIPTION
Introducing a straightforward fix for how we load the model.

Changes:
1. Removing the parameters freeze.
2. Applying LoRA and injecting the weights in the correct order of each case.