### PR TITLE
Fixed the PyTDC import methods according to the tdc API update

### DIFF
--- a/mammal/examples/carcinogenicity/pl_data_module.py
+++ b/mammal/examples/carcinogenicity/pl_data_module.py
@@ -6,7 +6,7 @@ from fuse.data.ops.ops_read import OpReadDataframe
 from fuse.data.pipelines.pipeline_default import PipelineDefault
 from fuse.data.tokenizers.modular_tokenizer.op import ModularTokenizerOp
 from fuse.data.utils.collates import CollateDefault
-from tdc.single_pred import Tox
+from tdc.single_pred.tox import Tox
 from torch.utils.data.dataloader import DataLoader
 
 from mammal.keys import *  # noqa

--- a/mammal/examples/dti_bindingdb_kd/pl_data_module.py
+++ b/mammal/examples/dti_bindingdb_kd/pl_data_module.py
@@ -7,7 +7,7 @@ from fuse.data.pipelines.pipeline_default import PipelineDefault
 from fuse.data.tokenizers.modular_tokenizer.op import ModularTokenizerOp
 from fuse.data.tokenizers.modular_tokenizer.special_tokens import special_wrap_input
 from fuse.data.utils.collates import CollateDefault
-from tdc.multi_pred import DTI
+from tdc.multi_pred.dti import DTI
 from torch.utils.data.dataloader import DataLoader
 
 from mammal.keys import *  # noqa


### PR DESCRIPTION
Fixed the PyTDC import methods according to the tdc API update

- tox: https://tdc.readthedocs.io/en/main/tdc.single_pred.html#module-tdc.single_pred.tox
- dti: https://tdc.readthedocs.io/en/main/tdc.multi_pred.html#module-tdc.multi_pred.dti